### PR TITLE
useEffect-cleanup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>usePopcorn</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
**useEffect**
- Add webbrowser tab title according to the page name
- Added AbortController: a native browser API for clean-up function
- Abort the signal everytime there is a keyboard input in the search field
- Reset setError(“”) before and  after the setMovies(data.Search)
**Extra small feature**
- Listening to a keypress : Classical DOM stuff in the MovieDetails Component
- Attach and Romove eventlistener to the document
